### PR TITLE
Add VideoProxy.restart() and isRunning() for foreground recovery

### DIFF
--- a/lib/download/download_pool.dart
+++ b/lib/download/download_pool.dart
@@ -295,7 +295,13 @@ class DownloadPool {
   }
 
   void dispose() {
-    _taskList.forEach((e) => updateTaskById(e.id, DownloadStatus.PAUSED));
+    // Force-cancel all in-flight download requests directly.
+    // When the app returns from background, TCP connections are dead and
+    // Dio's onReceiveProgress callback will never fire, so we must cancel
+    // tokens explicitly to unblock any pending futures.
+    for (final task in _taskList) {
+      task.cancelToken?.cancel('DownloadPool disposed');
+    }
     _taskList.clear();
     _streamController.close();
     _client.close();

--- a/lib/proxy/local_proxy_server.dart
+++ b/lib/proxy/local_proxy_server.dart
@@ -30,6 +30,9 @@ class LocalProxyServer {
   /// The underlying server socket instance.
   ServerSocket? server;
 
+  /// Health check timer reference for proper cleanup.
+  Timer? _healthCheckTimer;
+
   /// Starts the proxy server.
   /// Binds to the configured IP and port, and listens for incoming connections.
   /// If the port is already in use, it will try the next port.
@@ -55,7 +58,8 @@ class LocalProxyServer {
   }
 
   void startHealthCheck() {
-    Timer.periodic(Duration(seconds: 10), (timer) async {
+    _healthCheckTimer?.cancel();
+    _healthCheckTimer = Timer.periodic(Duration(seconds: 10), (timer) async {
       try {
         final socket = await Socket.connect(
           Config.ip,
@@ -73,13 +77,37 @@ class LocalProxyServer {
 
   void retry() {
     logD('Proxy server restarting...');
+    _healthCheckTimer?.cancel();
+    _healthCheckTimer = null;
     server?.close();
+    server = null;
     Future.delayed(Duration(seconds: 1), start);
   }
 
-  /// Shuts down the proxy server and closes the socket.
+  /// Restarts the proxy server.
+  ///
+  /// Closes the existing server and health check timer, then starts a new
+  /// server on the same port. This is useful when the app returns to the
+  /// foreground after the OS has killed the server socket in the background.
+  Future<void> restart() async {
+    logD('Proxy server restart requested...');
+    _healthCheckTimer?.cancel();
+    _healthCheckTimer = null;
+    try {
+      await server?.close();
+    } catch (_) {
+      // Server may already be dead (killed by OS in background).
+    }
+    server = null;
+    await start();
+  }
+
+  /// Shuts down the proxy server and cancels the health check timer.
   Future<void> close() async {
+    _healthCheckTimer?.cancel();
+    _healthCheckTimer = null;
     await server?.close();
+    server = null;
   }
 
   /// Handles an incoming socket connection.

--- a/lib/proxy/local_proxy_server.dart
+++ b/lib/proxy/local_proxy_server.dart
@@ -49,10 +49,12 @@ class LocalProxyServer {
       }
     } on SocketException catch (e) {
       logW('Proxy server Socket close: $e');
-      // If the port is occupied (error code 98), increment port and retry.
-      if (e.osError?.errorCode == 98) {
+      // If the port is occupied (EADDRINUSE), increment port and retry.
+      // Error code 48 on macOS/iOS, 98 on Linux.
+      final code = e.osError?.errorCode;
+      if (code == 48 || code == 98) {
         Config.port = Config.port + 1;
-        start();
+        await start();
       }
     }
   }

--- a/lib/proxy/video_proxy.dart
+++ b/lib/proxy/video_proxy.dart
@@ -17,6 +17,9 @@ class VideoProxy {
   /// Whether [init] has been called.
   static bool _initialized = false;
 
+  /// Stored concurrency setting for recreating the download manager on restart.
+  static int _maxConcurrentDownloads = 4;
+
   /// The local HTTP proxy server instance.
   static late LocalProxyServer _localProxyServer;
 
@@ -78,6 +81,7 @@ class VideoProxy {
     httpClientBuilderImpl = httpClientBuilder ?? HttpClientDefault();
 
     // Initialize the download manager with the specified concurrency.
+    _maxConcurrentDownloads = maxConcurrentDownloads;
     downloadManager = DownloadManager(maxConcurrentDownloads);
 
     // Set the URL matcher implementation (custom or default).
@@ -86,17 +90,25 @@ class VideoProxy {
     _initialized = true;
   }
 
-  /// Restarts the local proxy server without re-initializing other components
-  /// (cache, download manager, URL matcher, etc.).
+  /// Restarts the local proxy server and recreates the download manager.
   ///
-  /// This is intended to be called when the app returns to the foreground
-  /// after the OS has suspended or killed the proxy server in the background.
+  /// When the app returns from background, the OS may have killed TCP
+  /// connections between the download manager (Dio) and the CDN. Simply
+  /// restarting the server socket is not enough — the download manager's
+  /// in-flight tasks and HTTP client hold stale connection state that can
+  /// cause requests to hang. This method disposes the old download manager
+  /// and creates a fresh one so that all subsequent requests use new
+  /// connections.
   ///
   /// Throws [StateError] if [init] has not been called yet.
   static Future<void> restart() async {
     if (!_initialized) {
       throw StateError('VideoProxy.init() must be called before restart()');
     }
+    // Dispose stale download state (dead TCP connections, in-flight tasks)
+    // and recreate with a fresh Dio client.
+    downloadManager.dispose();
+    downloadManager = DownloadManager(_maxConcurrentDownloads);
     await _localProxyServer.restart();
   }
 

--- a/lib/proxy/video_proxy.dart
+++ b/lib/proxy/video_proxy.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_hls_parser/flutter_hls_parser.dart';
 
 import '../download/download_manager.dart';
@@ -12,6 +14,9 @@ import 'local_proxy_server.dart';
 /// Manages the initialization and configuration of the local video proxy server,
 /// HLS playlist parser, download manager, and URL matcher for video streaming and caching.
 class VideoProxy {
+  /// Whether [init] has been called.
+  static bool _initialized = false;
+
   /// The local HTTP proxy server instance.
   static late LocalProxyServer _localProxyServer;
 
@@ -77,5 +82,41 @@ class VideoProxy {
 
     // Set the URL matcher implementation (custom or default).
     urlMatcherImpl = urlMatcher ?? UrlMatcherDefault();
+
+    _initialized = true;
+  }
+
+  /// Restarts the local proxy server without re-initializing other components
+  /// (cache, download manager, URL matcher, etc.).
+  ///
+  /// This is intended to be called when the app returns to the foreground
+  /// after the OS has suspended or killed the proxy server in the background.
+  ///
+  /// Throws [StateError] if [init] has not been called yet.
+  static Future<void> restart() async {
+    if (!_initialized) {
+      throw StateError('VideoProxy.init() must be called before restart()');
+    }
+    await _localProxyServer.restart();
+  }
+
+  /// Checks whether the proxy server is currently reachable.
+  ///
+  /// Returns `true` if a TCP connection to the proxy succeeds, `false`
+  /// otherwise. This can be used to decide whether [restart] is needed
+  /// (e.g., after returning from background).
+  static Future<bool> isRunning() async {
+    if (!_initialized) return false;
+    try {
+      final socket = await Socket.connect(
+        Config.ip,
+        Config.port,
+        timeout: Duration(seconds: 1),
+      );
+      socket.destroy();
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
## Problem

When an app goes to the background on iOS/Android, the OS may kill the proxy server's `ServerSocket`. The existing health check `Timer.periodic` is also suspended while the app is in the background, so it cannot recover the server before the app returns to the foreground.

This means video players that rely on the local proxy (`toLocalUri()`) fail to connect when the app resumes, and since most players don't auto-retry, playback is permanently broken until the app is restarted.

Additionally, even after restarting the server socket, the `DownloadManager`'s internal HTTP client (Dio) and in-flight download tasks retain stale TCP connections to the CDN. These dead connections cause new requests to hang because:
- In-flight tasks in `DOWNLOADING` status occupy pool slots, blocking new downloads
- Dio's `onReceiveProgress` callback never fires on dead connections, so `CancelToken`s are never cancelled
- The Dio HTTP client may attempt to reuse dead connections from its pool

## Solution

### `LocalProxyServer`
- Store the health check `Timer` reference (`_healthCheckTimer`) so it can be properly cancelled
- Cancel existing timer before creating a new one in `startHealthCheck()` (prevents timer accumulation)
- Clean up timer and server reference in `retry()` and `close()`
- Add `restart()` method that safely closes the dead server and starts a new one on the same port

### `VideoProxy`
- Track initialization state with `_initialized` flag
- Store `_maxConcurrentDownloads` for recreating the download manager on restart
- Add `restart()` — restarts the proxy server **and** recreates the `DownloadManager` with a fresh Dio client to clear stale connection state
- Add `isRunning()` — checks if the proxy server is reachable via TCP connection

### `DownloadPool`
- `dispose()`: Force-cancel all `CancelToken`s directly instead of relying on `onReceiveProgress` (which never fires on dead connections)

## Usage

```dart
// In app lifecycle listener (e.g., AppLifecycleListener.onResume)
void onResume() async {
  if (!await VideoProxy.isRunning()) {
    await VideoProxy.restart();
  }
  // Then re-open media in your video players
}
```