### PR TITLE
Fix LruCacheStorage size ledger drift

### DIFF
--- a/lib/cache/lru_cache_impl.dart
+++ b/lib/cache/lru_cache_impl.dart
@@ -13,10 +13,9 @@ abstract class LruCacheImpl<K, V> extends LruCache<K, V> {
   /// Constructs an [LruCacheImpl] with the specified [maxSize].
   ///
   /// Throws an assertion error if [maxSize] is not greater than 0.
-  LruCacheImpl(int maxSize) {
+  LruCacheImpl(this.maxSize) {
     assert(maxSize > 0, 'maxSize must be greater than 0');
-    this.maxSize = maxSize;
-    this.map = LinkedHashMap<K, V>();
+    map = LinkedHashMap<K, V>();
   }
 
   /// The map that stores the cache entries in access order.
@@ -64,8 +63,8 @@ abstract class LruCacheImpl<K, V> extends LruCache<K, V> {
     assert(maxSize > 0, 'maxSize must be greater than 0');
     await lock.synchronized(() {
       this.maxSize = maxSize;
-      trimToSize(maxSize);
     });
+    await trimToSize(maxSize);
   }
 
   /// Returns a string representation of the cache, including statistics such as
@@ -74,7 +73,7 @@ abstract class LruCacheImpl<K, V> extends LruCache<K, V> {
   String toString() {
     final int accesses = hitCount + missCount;
     final int hitPercent = accesses != 0 ? (100 * hitCount ~/ accesses) : 0;
-    return '${runtimeType} [ '
+    return '$runtimeType [ '
         'maxSize=$maxSize, '
         'hits=$hitCount, '
         'misses=$missCount, '

--- a/lib/cache/lru_cache_memory.dart
+++ b/lib/cache/lru_cache_memory.dart
@@ -11,7 +11,7 @@ class LruCacheMemory extends LruCacheImpl<String, Uint8List> {
   /// Constructs an [LruCacheMemory] with the specified [maxSize] in bytes.
   ///
   /// Throws an assertion error if [maxSize] is not greater than 0.
-  LruCacheMemory(int maxSize) : super(maxSize);
+  LruCacheMemory(super.maxSize);
 
   /// Retrieves the value associated with the given [key], or `null` if not present.
   ///
@@ -48,7 +48,7 @@ class LruCacheMemory extends LruCacheImpl<String, Uint8List> {
       }
       map[key] = value;
 
-      trimToSize(maxSize);
+      _trimToSizeLocked(maxSize);
       return previous;
     });
   }
@@ -77,32 +77,36 @@ class LruCacheMemory extends LruCacheImpl<String, Uint8List> {
   @override
   Future<void> trimToSize(int maxSize) async {
     await lock.synchronized(() {
-      while (true) {
-        String key;
-        Uint8List value;
-
-        if (size < 0 || (map.isEmpty && size != 0)) {
-          throw StateError(
-            '$runtimeType.sizeOf() is reporting inconsistent results!',
-          );
-        }
-
-        if (size <= maxSize) {
-          break;
-        }
-
-        final toEvict = _eldest();
-        if (toEvict == null) {
-          break;
-        }
-
-        key = toEvict.key;
-        value = toEvict.value;
-        map.remove(key);
-        size -= value.lengthInBytes;
-        evictionCount++;
-      }
+      _trimToSizeLocked(maxSize);
     });
+  }
+
+  void _trimToSizeLocked(int maxSize) {
+    while (true) {
+      String key;
+      Uint8List value;
+
+      if (size < 0 || (map.isEmpty && size != 0)) {
+        throw StateError(
+          '$runtimeType.sizeOf() is reporting inconsistent results!',
+        );
+      }
+
+      if (size <= maxSize) {
+        break;
+      }
+
+      final toEvict = _eldest();
+      if (toEvict == null) {
+        break;
+      }
+
+      key = toEvict.key;
+      value = toEvict.value;
+      map.remove(key);
+      size -= value.lengthInBytes;
+      evictionCount++;
+    }
   }
 
   /// Returns the eldest entry in the cache, or `null` if the cache is empty.

--- a/lib/cache/lru_cache_singleton.dart
+++ b/lib/cache/lru_cache_singleton.dart
@@ -37,7 +37,7 @@ class LruCacheSingleton {
   late LruCacheStorage _storageCache;
 
   /// Lock for synchronizing storage cache initialization.
-  Lock _lock = Lock();
+  final Lock _lock = Lock();
 
   /// Flag indicating whether the storage cache has been initialized.
   bool _isStorageInit = false;
@@ -117,12 +117,12 @@ class LruCacheSingleton {
     for (FileSystemEntity entity in files) {
       final stat = await entity.stat();
       if (stat.type == FileSystemEntityType.file) {
-        String filePath = entity.path;
-        await entity.delete(recursive: true);
-        await storageRemove(filePath);
+        await _removeStorageFile(entity);
       }
     }
-    await dir.delete(recursive: true);
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
   }
 
   /// Returns the formatted size of the disk cache.
@@ -155,8 +155,9 @@ class LruCacheSingleton {
         FileStat stat = await file.stat();
         if (stat.type == FileSystemEntityType.file) {
           String key = basenameWithoutExtension(file.path);
-          _storageCache.map[key] = file;
-          _storageCache.size += stat.size;
+          // Restore through LruCacheStorage so size and per-key ledgers stay
+          // in sync. Writing map/size directly caused stale startup state.
+          await _storageCache.restore(key, file, stat.size);
         }
       }
     });
@@ -183,17 +184,25 @@ class LruCacheSingleton {
           String directoryName = basename(file.path);
           if (directoryName == key) {
             Directory directory = file as Directory;
-            await directory.list(recursive: true).forEach((subFile) async {
+            await for (final subFile in directory.list(recursive: true)) {
               if (subFile is File) {
-                String subKey = basenameWithoutExtension(subFile.path);
-                await _memoryCache.remove(subKey);
+                await _removeStorageFile(subFile);
               }
-            });
-            await file.delete(recursive: true);
-            await directory.delete(recursive: true);
+            }
+            if (await directory.exists()) {
+              await directory.delete(recursive: true);
+            }
           }
         }
       }
     }
+  }
+
+  Future<void> _removeStorageFile(FileSystemEntity file) async {
+    final String key = basenameWithoutExtension(file.path);
+    // Directory cleanup must remove by cache key, not by full path. Passing a
+    // path here leaves the storage map and size ledger dirty.
+    await _storageCache.remove(key);
+    await _memoryCache.remove(key);
   }
 }

--- a/lib/cache/lru_cache_storage.dart
+++ b/lib/cache/lru_cache_storage.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import '../ext/log_ext.dart';
 import 'lru_cache_impl.dart';
 
 /// An LRU cache implementation for storing file system entities (such as files) on disk.
@@ -11,7 +12,14 @@ class LruCacheStorage extends LruCacheImpl<String, FileSystemEntity> {
   /// Constructs an [LruCacheStorage] with the specified [maxSize] in bytes.
   ///
   /// Throws an assertion error if [maxSize] is not greater than 0.
-  LruCacheStorage(int maxSize) : super(maxSize);
+  LruCacheStorage(super.maxSize);
+
+  /// Size snapshot for each key.
+  ///
+  /// Disk files can be deleted or changed outside this cache. Keeping the size
+  /// that was added lets [remove] subtract the same value even when `stat()`
+  /// later reports zero or throws, which prevents map/size drift.
+  final Map<String, int> _entrySizes = <String, int>{};
 
   /// Retrieves the file associated with the given [key], or `null` if not present or does not exist.
   ///
@@ -20,10 +28,20 @@ class LruCacheStorage extends LruCacheImpl<String, FileSystemEntity> {
   Future<FileSystemEntity?> get(String key) async {
     assert(key.isNotEmpty, 'key must not be empty');
     return await lock.synchronized(() async {
-      File? file = map[key] as File?;
+      final FileSystemEntity? entity = map[key];
+      final File? file = entity is File ? entity : null;
       if (file != null && await file.exists()) {
+        // LinkedHashMap is insertion-ordered, so reinsert on hit to make
+        // eviction approximate access-order LRU instead of creation order.
+        map.remove(key);
+        map[key] = file;
         hitCount++;
         return file;
+      }
+      if (entity != null) {
+        // The file disappeared outside the cache. Drop only the index entry so
+        // later trims do not see an empty map with a non-zero size ledger.
+        await _removeEntryLocked(key, deleteFile: false);
       }
       missCount++;
       return null;
@@ -40,15 +58,19 @@ class LruCacheStorage extends LruCacheImpl<String, FileSystemEntity> {
     assert(key.isNotEmpty, 'key must not be empty');
     return await lock.synchronized(() async {
       putCount++;
-      size += (await value.stat()).size;
-
+      final int valueSize = await _safeSize(value);
       final FileSystemEntity? previous = map[key];
       if (previous != null) {
-        size -= (await previous.stat()).size;
+        // Replace the bookkeeping first; deleting the same path here would
+        // remove the new file when callers overwrite an existing key in place.
+        await _removeEntryLocked(key, deleteFile: false);
       }
+
+      size += valueSize;
+      _entrySizes[key] = valueSize;
       map[key] = value;
 
-      trimToSize(maxSize);
+      await _trimToSizeLocked(maxSize);
       return previous;
     });
   }
@@ -62,12 +84,7 @@ class LruCacheStorage extends LruCacheImpl<String, FileSystemEntity> {
   Future<FileSystemEntity?> remove(String key) async {
     assert(key.isNotEmpty, 'key must not be empty');
     return await lock.synchronized(() async {
-      final FileSystemEntity? previous = map.remove(key);
-      if (previous != null) {
-        size -= (await previous.stat()).size;
-        await previous.delete();
-      }
-      return previous;
+      return _removeEntryLocked(key);
     });
   }
 
@@ -79,37 +96,105 @@ class LruCacheStorage extends LruCacheImpl<String, FileSystemEntity> {
   @override
   Future<void> trimToSize(int maxSize) async {
     await lock.synchronized(() async {
-      if (size < 0 || (map.isEmpty && size != 0)) {
-        throw StateError(
-            '$runtimeType.sizeOf() is reporting inconsistent results!');
-      }
-
-      if (size <= maxSize) return;
-
-      // Sort entries by last modified time (oldest first)
-      final sortedEntries = map.entries.toList()
-        ..sort((a, b) => a.value.dataTime.compareTo(b.value.dataTime));
-
-      int removeSize = 0;
-      List<String> keysToRemove = [];
-      for (final entry in sortedEntries) {
-        if (size - removeSize >= maxSize || removeSize <= maxSize * 0.2) {
-          removeSize += (await entry.value.stat()).size;
-          keysToRemove.add(entry.key);
-        } else {
-          break;
-        }
-      }
-      for (final key in keysToRemove) {
-        FileSystemEntity? toEvict = map.remove(key);
-        if (toEvict != null) {
-          size -= (await toEvict.stat()).size;
-          await toEvict.delete();
-          evictionCount++;
-        }
-      }
+      await _trimToSizeLocked(maxSize);
     });
   }
+
+  /// Adds an existing file without triggering eviction.
+  ///
+  /// Used while rebuilding the cache index from disk during startup.
+  Future<void> restore(
+    String key,
+    FileSystemEntity value,
+    int valueSize,
+  ) async {
+    assert(key.isNotEmpty, 'key must not be empty');
+    await lock.synchronized(() async {
+      if (map.containsKey(key)) {
+        await _removeEntryLocked(key, deleteFile: false);
+      }
+      map[key] = value;
+      _entrySizes[key] = valueSize;
+      size += valueSize;
+    });
+  }
+
+  Future<void> _trimToSizeLocked(int maxSize) async {
+    // Repair before evicting because the file system may have changed since
+    // the last cache operation. Throwing here would recreate the Firebase
+    // non-fatal loop this class is trying to avoid.
+    await _repairSizeLocked();
+
+    while (size > maxSize) {
+      final toEvict = _eldest();
+      if (toEvict == null) {
+        size = 0;
+        return;
+      }
+
+      await _removeEntryLocked(toEvict.key);
+      evictionCount++;
+    }
+  }
+
+  Future<void> _repairSizeLocked() async {
+    int recalculatedSize = 0;
+    final missingKeys = <String>[];
+
+    for (final entry in map.entries) {
+      if (await entry.value.exists()) {
+        final entrySize = await _safeSize(entry.value);
+        _entrySizes[entry.key] = entrySize;
+        recalculatedSize += entrySize;
+      } else {
+        missingKeys.add(entry.key);
+      }
+    }
+
+    for (final key in missingKeys) {
+      // Missing files are already gone, so only remove their bookkeeping.
+      map.remove(key);
+      _entrySizes.remove(key);
+    }
+
+    size = recalculatedSize;
+  }
+
+  Future<FileSystemEntity?> _removeEntryLocked(
+    String key, {
+    bool deleteFile = true,
+  }) async {
+    final FileSystemEntity? previous = map.remove(key);
+    if (previous == null) return null;
+
+    size -= _entrySizes.remove(key) ?? await _safeSize(previous);
+    if (size < 0) size = 0;
+
+    if (deleteFile) {
+      try {
+        if (await previous.exists()) {
+          await previous.delete(recursive: true);
+        }
+      } on FileSystemException catch (e) {
+        // The index is already repaired. File deletion is best-effort because
+        // the OS or another cleanup path may race us between exists/delete.
+        logE('[LruCacheStorage] Delete cache file failed: $e');
+      }
+    }
+    return previous;
+  }
+
+  Future<int> _safeSize(FileSystemEntity entity) async {
+    try {
+      return (await entity.stat()).size;
+    } on FileSystemException {
+      // Treat missing/unreadable files as zero-byte during repair; the next
+      // repair pass will remove entries whose paths no longer exist.
+      return 0;
+    }
+  }
+
+  MapEntry<String, FileSystemEntity>? _eldest() => map.entries.firstOrNull;
 }
 
 /// Extension to get the last modified time of a [FileSystemEntity].

--- a/lib/download/download_pool.dart
+++ b/lib/download/download_pool.dart
@@ -198,8 +198,8 @@ class DownloadPool {
         }
       },
       options: Options(headers: headers),
-    ).then((response) {
-      _downloadResponse(task, startTime);
+    ).then((response) async {
+      await _downloadResponse(task, startTime);
     }).catchError((error) {
       _downloadError(task, error);
     });
@@ -246,13 +246,22 @@ class DownloadPool {
     }
   }
 
-  void _downloadResponse(DownloadTask task, DateTime startTime) {
+  Future<void> _downloadResponse(DownloadTask task, DateTime startTime) async {
     File saveFile = File(task.savePath);
     task.progress = 1;
     task.data = saveFile.readAsBytesSync();
     updateTaskById(task.id, DownloadStatus.COMPLETED);
-    LruCacheSingleton().memoryPut(task.matchUrl, Uint8List.fromList(task.data));
-    LruCacheSingleton().storagePut(task.matchUrl, saveFile);
+    try {
+      // Cache registration is an optimization after the network download has
+      // succeeded. Do not turn cache bookkeeping failures into download errors.
+      await LruCacheSingleton().memoryPut(
+        task.matchUrl,
+        Uint8List.fromList(task.data),
+      );
+      await LruCacheSingleton().storagePut(task.matchUrl, saveFile);
+    } catch (e) {
+      logE('[DownloadPool] Cache registration failed: $e');
+    }
     int duration = DateTime.now().difference(startTime).inSeconds;
     logV('[DownloadPool] Download done time: $duration s: ${task.toString()}');
     FunctionProxy.debounce(roundTask);

--- a/lib/parser/url_parser_default.dart
+++ b/lib/parser/url_parser_default.dart
@@ -30,15 +30,19 @@ class UrlParserDefault implements UrlParser {
   Future<Uint8List?> cache(DownloadTask task) async {
     Uint8List? dataMemory = await LruCacheSingleton().memoryGet(task.matchUrl);
     if (dataMemory != null) {
-      logD('From memory: ${dataMemory.lengthInBytes.toMemorySize}, '
-          'total memory size: ${await LruCacheSingleton().memoryFormatSize()}'
-          'Request range：${task.startRange}-${task.endRange}');
+      logD(
+        'From memory: ${dataMemory.lengthInBytes.toMemorySize}, '
+        'total memory size: ${await LruCacheSingleton().memoryFormatSize()}'
+        'Request range：${task.startRange}-${task.endRange}',
+      );
       return dataMemory;
     }
     Uint8List? dataFile = await LruCacheSingleton().storageGet(task.matchUrl);
     if (dataFile != null) {
-      logD('From file: ${task.matchUrl} '
-          'Request range：${task.startRange}-${task.endRange}');
+      logD(
+        'From file: ${task.matchUrl} '
+        'Request range：${task.startRange}-${task.endRange}',
+      );
       await LruCacheSingleton().memoryPut(task.matchUrl, dataFile);
       return dataFile;
     }
@@ -134,8 +138,12 @@ class UrlParserDefault implements UrlParser {
     int requestRangeEnd,
     Map<String, String> headers,
   ) async {
-    DownloadTask task =
-        DownloadTask(uri: uri, startRange: 0, endRange: 1, headers: headers);
+    DownloadTask task = DownloadTask(
+      uri: uri,
+      startRange: 0,
+      endRange: 1,
+      headers: headers,
+    );
     Uint8List? data = await cache(task);
     int contentLength = 0;
     if (data != null) {
@@ -143,17 +151,15 @@ class UrlParserDefault implements UrlParser {
     }
     if (contentLength == 0) {
       contentLength = await head(uri, headers: headers);
-      String filePath = '${await FileExt.createCachePath(task.uri.generateMd5)}'
-          '/${task.saveFileName}';
-      File file = File(filePath);
-      file.writeAsString(contentLength.toString());
-      LruCacheSingleton().storagePut(task.matchUrl, file);
+      await _cacheContentLength(task, contentLength);
     }
 
     requestRangeEnd = contentLength - 1;
     responseHeaders.add('content-length: ${contentLength - requestRangeStart}');
-    responseHeaders.add('content-range: bytes '
-        '$requestRangeStart-$requestRangeEnd/$contentLength');
+    responseHeaders.add(
+      'content-range: bytes '
+      '$requestRangeStart-$requestRangeEnd/$contentLength',
+    );
     await socket.append(responseHeaders.join('\r\n'));
 
     bool downloading = true;
@@ -168,8 +174,10 @@ class UrlParserDefault implements UrlParser {
         endRange: endRange,
         headers: headers,
       );
-      logD('Start ${task.url} '
-          'Request range：${task.startRange}-${task.endRange}');
+      logD(
+        'Start ${task.url} '
+        'Request range：${task.startRange}-${task.endRange}',
+      );
 
       Uint8List? data = await cache(task);
       // if the task has been added, wait for the download to complete
@@ -232,8 +240,12 @@ class UrlParserDefault implements UrlParser {
   ) async {
     if ((requestRangeStart == 0 && requestRangeEnd == 1) ||
         requestRangeEnd == -1) {
-      DownloadTask task =
-          DownloadTask(uri: uri, startRange: 0, endRange: 1, headers: headers);
+      DownloadTask task = DownloadTask(
+        uri: uri,
+        startRange: 0,
+        endRange: 1,
+        headers: headers,
+      );
       Uint8List? data = await cache(task);
       int contentLength = 0;
       if (data != null) {
@@ -241,12 +253,7 @@ class UrlParserDefault implements UrlParser {
       }
       if (contentLength == 0) {
         contentLength = await head(uri, headers: headers);
-        String filePath =
-            '${await FileExt.createCachePath(task.uri.generateMd5)}'
-            '/${task.saveFileName}';
-        File file = File(filePath);
-        file.writeAsString(contentLength.toString());
-        LruCacheSingleton().storagePut(task.matchUrl, file);
+        await _cacheContentLength(task, contentLength);
       }
       if (requestRangeStart == 0 && requestRangeEnd == 1) {
         responseHeaders.add('content-range: bytes 0-1/$contentLength');
@@ -275,8 +282,10 @@ class UrlParserDefault implements UrlParser {
         endRange: endRange,
         headers: headers,
       );
-      logD('Start ${task.url} '
-          'Request range：${task.startRange}-${task.endRange}');
+      logD(
+        'Start ${task.url} '
+        'Request range：${task.startRange}-${task.endRange}',
+      );
 
       Uint8List? data = await cache(task);
       // if the task has been added, wait for the download to complete
@@ -340,8 +349,9 @@ class UrlParserDefault implements UrlParser {
     }
     Response response = await client.headUri(uri);
     // Get content-length from content-range, if failed get from content-length
-    String? contentRange =
-        response.headers.value(HttpHeaders.contentRangeHeader);
+    String? contentRange = response.headers.value(
+      HttpHeaders.contentRangeHeader,
+    );
     if (contentRange != null) {
       final match = RegExp(r'bytes (\d+)-(\d+)/(\d+)').firstMatch(contentRange);
       if (match != null && match.group(3) != null) {
@@ -351,10 +361,28 @@ class UrlParserDefault implements UrlParser {
         }
       }
     }
-    String? contentLength =
-        response.headers.value(HttpHeaders.contentLengthHeader);
+    String? contentLength = response.headers.value(
+      HttpHeaders.contentLengthHeader,
+    );
     client.close();
     return int.tryParse(contentLength ?? '-1') ?? -1;
+  }
+
+  Future<void> _cacheContentLength(
+    DownloadTask task,
+    int contentLength,
+  ) async {
+    try {
+      // Content length is already known by the caller. This small metadata file
+      // only speeds up later requests, so failures must not block the response.
+      String filePath = '${await FileExt.createCachePath(task.uri.generateMd5)}'
+          '/${task.saveFileName}';
+      File file = File(filePath);
+      await file.writeAsString(contentLength.toString());
+      await LruCacheSingleton().storagePut(task.matchUrl, file);
+    } catch (e) {
+      logE('[UrlParserDefault] Cache content length failed: $e');
+    }
   }
 
   /// Manages concurrent download tasks.
@@ -379,8 +407,9 @@ class UrlParserDefault implements UrlParser {
       bool isExit = VideoProxy.downloadManager.allTasks
           .where((e) => e.matchUrl == newTask.matchUrl)
           .isNotEmpty;
-      Uint8List? dataMemory =
-          await LruCacheSingleton().memoryGet(newTask.matchUrl);
+      Uint8List? dataMemory = await LruCacheSingleton().memoryGet(
+        newTask.matchUrl,
+      );
       if (dataMemory != null) isExit = true;
       newTask.cacheDir = await FileExt.createCachePath(newTask.uri.generateMd5);
       File file = File(newTask.savePath);

--- a/lib/parser/url_parser_mp4.dart
+++ b/lib/parser/url_parser_mp4.dart
@@ -29,15 +29,19 @@ class UrlParserMp4 implements UrlParser {
   Future<Uint8List?> cache(DownloadTask task) async {
     Uint8List? dataMemory = await LruCacheSingleton().memoryGet(task.matchUrl);
     if (dataMemory != null) {
-      logD('From memory: ${dataMemory.lengthInBytes.toMemorySize}, '
-          'total memory size: ${await LruCacheSingleton().memoryFormatSize()}'
-          'Request range：${task.startRange}-${task.endRange}');
+      logD(
+        'From memory: ${dataMemory.lengthInBytes.toMemorySize}, '
+        'total memory size: ${await LruCacheSingleton().memoryFormatSize()}'
+        'Request range：${task.startRange}-${task.endRange}',
+      );
       return dataMemory;
     }
     Uint8List? dataFile = await LruCacheSingleton().storageGet(task.matchUrl);
     if (dataFile != null) {
-      logD('From file: ${task.matchUrl} '
-          'Request range：${task.startRange}-${task.endRange}');
+      logD(
+        'From file: ${task.matchUrl} '
+        'Request range：${task.startRange}-${task.endRange}',
+      );
       await LruCacheSingleton().memoryPut(task.matchUrl, dataFile);
       return dataFile;
     }
@@ -133,8 +137,12 @@ class UrlParserMp4 implements UrlParser {
     int requestRangeEnd,
     Map<String, String> headers,
   ) async {
-    DownloadTask task =
-        DownloadTask(uri: uri, startRange: 0, endRange: 1, headers: headers);
+    DownloadTask task = DownloadTask(
+      uri: uri,
+      startRange: 0,
+      endRange: 1,
+      headers: headers,
+    );
     Uint8List? data = await cache(task);
     int contentLength = 0;
     if (data != null) {
@@ -142,17 +150,15 @@ class UrlParserMp4 implements UrlParser {
     }
     if (contentLength == 0) {
       contentLength = await head(uri, headers: headers);
-      String filePath = '${await FileExt.createCachePath(task.uri.generateMd5)}'
-          '/${task.saveFileName}';
-      File file = File(filePath);
-      file.writeAsString(contentLength.toString());
-      LruCacheSingleton().storagePut(task.matchUrl, file);
+      await _cacheContentLength(task, contentLength);
     }
 
     requestRangeEnd = contentLength - 1;
     responseHeaders.add('content-length: ${contentLength - requestRangeStart}');
-    responseHeaders.add('content-range: bytes '
-        '$requestRangeStart-$requestRangeEnd/$contentLength');
+    responseHeaders.add(
+      'content-range: bytes '
+      '$requestRangeStart-$requestRangeEnd/$contentLength',
+    );
     await socket.append(responseHeaders.join('\r\n'));
 
     bool downloading = true;
@@ -167,8 +173,10 @@ class UrlParserMp4 implements UrlParser {
         endRange: endRange,
         headers: headers,
       );
-      logD('Start ${task.url} '
-          'Request range：${task.startRange}-${task.endRange}');
+      logD(
+        'Start ${task.url} '
+        'Request range：${task.startRange}-${task.endRange}',
+      );
 
       Uint8List? data = await cache(task);
       // if the task has been added, wait for the download to complete
@@ -230,8 +238,12 @@ class UrlParserMp4 implements UrlParser {
   ) async {
     if ((requestRangeStart == 0 && requestRangeEnd == 1) ||
         requestRangeEnd == -1) {
-      DownloadTask task =
-          DownloadTask(uri: uri, startRange: 0, endRange: 1, headers: headers);
+      DownloadTask task = DownloadTask(
+        uri: uri,
+        startRange: 0,
+        endRange: 1,
+        headers: headers,
+      );
       Uint8List? data = await cache(task);
       int contentLength = 0;
       if (data != null) {
@@ -239,12 +251,7 @@ class UrlParserMp4 implements UrlParser {
       }
       if (contentLength == 0) {
         contentLength = await head(uri, headers: headers);
-        String filePath =
-            '${await FileExt.createCachePath(task.uri.generateMd5)}'
-            '/${task.saveFileName}';
-        File file = File(filePath);
-        file.writeAsString(contentLength.toString());
-        LruCacheSingleton().storagePut(task.matchUrl, file);
+        await _cacheContentLength(task, contentLength);
       }
       if (requestRangeStart == 0 && requestRangeEnd == 1) {
         responseHeaders.add('content-range: bytes 0-1/$contentLength');
@@ -273,8 +280,10 @@ class UrlParserMp4 implements UrlParser {
         endRange: endRange,
         headers: headers,
       );
-      logD('Start ${task.url} '
-          'Request range：${task.startRange}-${task.endRange}');
+      logD(
+        'Start ${task.url} '
+        'Request range：${task.startRange}-${task.endRange}',
+      );
 
       Uint8List? data = await cache(task);
       // if the task has been added, wait for the download to complete
@@ -338,8 +347,9 @@ class UrlParserMp4 implements UrlParser {
     }
     Response response = await client.headUri(uri);
     // Get content-length from content-range, if failed get from content-length
-    String? contentRange =
-        response.headers.value(HttpHeaders.contentRangeHeader);
+    String? contentRange = response.headers.value(
+      HttpHeaders.contentRangeHeader,
+    );
     if (contentRange != null) {
       final match = RegExp(r'bytes (\d+)-(\d+)/(\d+)').firstMatch(contentRange);
       if (match != null && match.group(3) != null) {
@@ -349,10 +359,28 @@ class UrlParserMp4 implements UrlParser {
         }
       }
     }
-    String? contentLength =
-        response.headers.value(HttpHeaders.contentLengthHeader);
+    String? contentLength = response.headers.value(
+      HttpHeaders.contentLengthHeader,
+    );
     client.close();
     return int.tryParse(contentLength ?? '-1') ?? -1;
+  }
+
+  Future<void> _cacheContentLength(
+    DownloadTask task,
+    int contentLength,
+  ) async {
+    try {
+      // Content length is already known by the caller. This small metadata file
+      // only speeds up later requests, so failures must not block the response.
+      String filePath = '${await FileExt.createCachePath(task.uri.generateMd5)}'
+          '/${task.saveFileName}';
+      File file = File(filePath);
+      await file.writeAsString(contentLength.toString());
+      await LruCacheSingleton().storagePut(task.matchUrl, file);
+    } catch (e) {
+      logE('[UrlParserMp4] Cache content length failed: $e');
+    }
   }
 
   /// Manages concurrent download tasks.
@@ -377,8 +405,9 @@ class UrlParserMp4 implements UrlParser {
       bool isExit = VideoProxy.downloadManager.allTasks
           .where((e) => e.matchUrl == newTask.matchUrl)
           .isNotEmpty;
-      Uint8List? dataMemory =
-          await LruCacheSingleton().memoryGet(newTask.matchUrl);
+      Uint8List? dataMemory = await LruCacheSingleton().memoryGet(
+        newTask.matchUrl,
+      );
       if (dataMemory != null) isExit = true;
       newTask.cacheDir = await FileExt.createCachePath(newTask.uri.generateMd5);
       File file = File(newTask.savePath);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,9 @@ dependencies:
 
 dev_dependencies:
   test: ^1.25.15
-  mockito: 5.4.6
+  mockito: ^5.6.4
+  path_provider_platform_interface: ^2.1.2
+  plugin_platform_interface: ^2.1.8
   flutter_test:
     sdk: flutter
 

--- a/test/cache/lru_cache_singleton_test.dart
+++ b/test/cache/lru_cache_singleton_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_video_caching/cache/lru_cache_singleton.dart';
 import 'package:flutter_video_caching/ext/file_ext.dart';
+import 'package:flutter_video_caching/ext/string_ext.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -19,10 +20,25 @@ class FakePathProviderPlatform extends Fake
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   group('LruCacheSingleton integration', () {
+    late Directory tempDir;
+    late LruCacheSingleton singleton;
+
     setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('lru_singleton_test');
       PathProviderPlatform.instance = FakePathProviderPlatform();
+      FileExt.cacheRootPath = '${tempDir.path}/videos';
+      singleton = LruCacheSingleton();
+      await singleton.storageClear();
+      await singleton.memoryClear();
     });
-    final singleton = LruCacheSingleton();
+
+    tearDown(() async {
+      FileExt.cacheRootPath = '';
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
     test('memory cache put/get/remove/clear', () async {
       final key = 'test_key';
       final value = Uint8List.fromList([1, 2, 3]);
@@ -60,5 +76,41 @@ void main() {
       final got3 = await singleton.storageGet(key);
       expect(got3, isNull);
     });
+
+    test(
+      'storageClearByDirPath removes storage entries by cache key',
+      () async {
+        final cacheDir = Directory(await FileExt.createCachePath('group'));
+        final file = File('${cacheDir.path}/entry.bin');
+        await file.writeAsBytes([1, 2, 3, 4]);
+        await singleton.storagePut('entry', file);
+
+        await singleton.storageClearByDirPath(cacheDir.path);
+
+        expect(await singleton.storageSizeInBytes(), 0);
+        expect(singleton.storageMap(), isEmpty);
+      },
+    );
+
+    test(
+      'removeCacheByUrl removes every storage entry in the URL directory',
+      () async {
+        const url = 'https://example.com/video.m3u8';
+        final cacheDir = Directory(
+          await FileExt.createCachePath(url.generateMd5),
+        );
+        final file1 = File('${cacheDir.path}/segment1.ts');
+        final file2 = File('${cacheDir.path}/segment2.ts');
+        await file1.writeAsBytes([1, 2, 3]);
+        await file2.writeAsBytes([4, 5, 6, 7]);
+        await singleton.storagePut('segment1', file1);
+        await singleton.storagePut('segment2', file2);
+
+        await singleton.removeCacheByUrl(url);
+
+        expect(await singleton.storageSizeInBytes(), 0);
+        expect(singleton.storageMap(), isEmpty);
+      },
+    );
   });
 }

--- a/test/cache/lru_cache_storage_test.dart
+++ b/test/cache/lru_cache_storage_test.dart
@@ -50,5 +50,49 @@ void main() {
       expect(await cache.get('c'), isNull);
       expect(await cache.get('d'), isNull);
     });
+
+    test('put waits for eviction before completing', () async {
+      cache = LruCacheStorage(5);
+      final file1 = File(p.join(tempDir.path, 'e.txt'));
+      final file2 = File(p.join(tempDir.path, 'f.txt'));
+      await file1.writeAsBytes([1, 2, 3, 4]);
+      await file2.writeAsBytes([5, 6, 7, 8]);
+
+      await cache.put('e', file1);
+      await cache.put('f', file2);
+
+      expect(cache.size, lessThanOrEqualTo(cache.maxSize));
+    });
+
+    test('get prunes missing files and repairs the size ledger', () async {
+      final file = File(p.join(tempDir.path, 'g.txt'));
+      await file.writeAsBytes([1, 2, 3]);
+      await cache.put('g', file);
+      await file.delete();
+
+      final result = await cache.get('g');
+
+      expect(result, isNull);
+      expect(cache.size, 0);
+      expect(cache.map, isEmpty);
+      await cache.trimToSize(cache.maxSize);
+    });
+
+    test(
+      'remove repairs the size ledger when the file was already deleted',
+      () async {
+        final file = File(p.join(tempDir.path, 'h.txt'));
+        await file.writeAsBytes([1, 2, 3]);
+        await cache.put('h', file);
+        await file.delete();
+
+        final removed = await cache.remove('h');
+
+        expect(removed, isNotNull);
+        expect(cache.size, 0);
+        expect(cache.map, isEmpty);
+        await cache.trimToSize(cache.maxSize);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes #46.

This PR makes LruCacheStorage bookkeeping self-healing when files are deleted or cleaned up outside the normal storage cache path.

Changes:

- track per-key file sizes so remove/repair can subtract the same value that was added
- prune missing files and repair the size ledger before trim/eviction
- restore startup cache entries through LruCacheStorage instead of writing map/size directly
- remove directory cleanup entries by cache key, not raw file path
- keep cache registration and parser content-length writes best-effort so cache bookkeeping failures do not fail successful requests
- add regression tests for missing files and URL directory cleanup

## Verification

- /Users/km/fvm/default/bin/flutter test test/cache/lru_cache_storage_test.dart test/cache/lru_cache_singleton_test.dart
- /Users/km/fvm/default/bin/dart analyze lib/cache/lru_cache_impl.dart lib/cache/lru_cache_memory.dart lib/cache/lru_cache_singleton.dart lib/cache/lru_cache_storage.dart lib/download/download_pool.dart lib/parser/url_parser_default.dart lib/parser/url_parser_mp4.dart test/cache/lru_cache_storage_test.dart test/cache/lru_cache_singleton_test.dart