### PR TITLE
fix: respond 206 for all Range requests, add Content-Range in parseIOS, clamp last-segment endRange

### DIFF
--- a/lib/parser/url_parser_mp4.dart
+++ b/lib/parser/url_parser_mp4.dart
@@ -87,7 +87,12 @@ class UrlParserMp4 implements UrlParser {
       RegExpMatch? rangeMatch = exp.firstMatch(headers['range'] ?? '');
       int requestRangeStart = int.tryParse(rangeMatch?.group(1) ?? '0') ?? 0;
       int requestRangeEnd = int.tryParse(rangeMatch?.group(2) ?? '0') ?? -1;
-      bool partial = requestRangeStart > 0 || requestRangeEnd > 0;
+      // Any request carrying a Range header must be answered with 206. The
+      // previous `start > 0 || end > 0` check returned 200 for `bytes=0-`, which
+      // makes ffmpeg/libmpv treat the stream as non-seekable (is_streamed=1):
+      // seeking jumps to EOF and, when moov sits at the tail, the final frames
+      // decode as garbage.
+      bool partial = rangeMatch != null;
       List<String> responseHeaders = <String>[
         partial ? 'HTTP/1.1 206 Partial Content' : 'HTTP/1.1 200 OK',
         'Accept-Ranges: bytes',
@@ -167,6 +172,13 @@ class UrlParserMp4 implements UrlParser {
     int endRange = startRange + Config.segmentSize - 1;
     int retry = 3;
     while (downloading) {
+      // The last segment's endRange must not exceed the file's last byte. When
+      // the requested range end is past EOF, some origins (e.g. Aliyun OSS) reply
+      // 200 + the whole file instead of a clamped 206; the serve loop then
+      // splices the file's head where its tail belongs, corrupting playback
+      // around the segment boundary (jump to EOF). requestRangeEnd is the file's
+      // last byte here (contentLength-1), so clamp to it.
+      if (endRange > requestRangeEnd) endRange = requestRangeEnd;
       DownloadTask task = DownloadTask(
         uri: uri,
         startRange: startRange,
@@ -266,6 +278,13 @@ class UrlParserMp4 implements UrlParser {
 
     int contentLength = requestRangeEnd - requestRangeStart + 1;
     responseHeaders.add('content-length: $contentLength');
+    // A 206 response must carry Content-Range; without it libmpv cannot map the
+    // byte offset of a seek and decodes segments as misaligned data (artifacts /
+    // jump to EOF). Mirrors parseAndroid. For open-ended requests (bytes=N-)
+    // requestRangeEnd was set to contentLength-1 above, so total = requestRangeEnd + 1.
+    responseHeaders.add(
+      'content-range: bytes $requestRangeStart-$requestRangeEnd/${requestRangeEnd + 1}',
+    );
     await socket.append(responseHeaders.join('\r\n'));
 
     bool downloading = true;
@@ -274,6 +293,13 @@ class UrlParserMp4 implements UrlParser {
     int endRange = startRange + Config.segmentSize - 1;
     int retry = 3;
     while (downloading) {
+      // The last segment's endRange must not exceed the file's last byte. When
+      // the requested range end is past EOF, some origins (e.g. Aliyun OSS) reply
+      // 200 + the whole file instead of a clamped 206; the serve loop then
+      // splices the file's head where its tail belongs, corrupting playback
+      // around the segment boundary (jump to EOF). requestRangeEnd is the file's
+      // last byte here (contentLength-1), so clamp to it.
+      if (endRange > requestRangeEnd) endRange = requestRangeEnd;
       DownloadTask task = DownloadTask(
         uri: uri,
         startRange: startRange,


### PR DESCRIPTION
## Problem

Two visible symptoms when the video's moov atom sits at the file tail
(a common layout on cloud storage such as Aliyun OSS):

1. **Tail-frame corruption ("??" / garbage frames at end of video)**
2. **Seek jumps to EOF near the last segment boundary**

Both are caused by three bugs in `parse()` / `parseAndroid()` / `parseIOS()`.

---

## Root causes

### Bug 1 - `parse()`: wrong status code for open-ended Range requests

```dart
// before
bool partial = requestRangeStart > 0 || requestRangeEnd > 0;
```

An open-ended request such as `Range: bytes=0-` has `start=0, end=0`, so
`partial` evaluates to `false` and the proxy replies `200 OK`.

ffmpeg / libmpv treats any `200` response to a Range request as a
non-seekable stream (`is_streamed = 1`). When the moov atom is at the file
tail, libmpv must seek to read it; with `is_streamed=1` that seek jumps to
EOF, causing the final frames to be decoded from garbage data.

### Bug 2 - `parseIOS()`: missing `Content-Range` response header

`parseAndroid()` already emits `content-range` on every 206 response.
`parseIOS()` did not. Without `Content-Range`, libmpv cannot verify the
byte offset of a seek target and misaligns segment boundaries, causing
artifacts and EOF jumps near the end of the file.

### Bug 3 - both parsers: last segment `endRange` not clamped to file size

```dart
int endRange = startRange + Config.segmentSize - 1;
// endRange can exceed contentLength - 1 for the last segment
```

When `endRange` exceeds the file size, **Aliyun OSS** (and likely other
origins) responds with `200 OK` + the entire file body instead of a
clamped `206 Partial Content`. The serve loop then reads
`data.sublist(0, remainingBytes)` - which is the **head** of the file, not
the tail - and splices it into the last segment's position, corrupting
playback and causing a seek jump to EOF.

Curl proof:
```
# file size = 2,395,628 bytes (last byte = 2,395,627)
# request beyond EOF:
curl -r 2000000-9999999 https://<oss-bucket>/video.mp4 -I
# ? HTTP/1.1 200 OK   (should be 206, or 416)
# ? Content-Length: 2395628   (returns whole file)

# request within bounds:
curl -r 2000000-2395627 https://<oss-bucket>/video.mp4 -I
# ? HTTP/1.1 206 Partial Content
# ? Content-Range: bytes 2000000-2395627/2395628
```

---

## Fix

**`parse()`** - treat the presence of a `Range` header as the sole signal
for 206, regardless of the numeric values:

```dart
// after
bool partial = rangeMatch != null;
```

**`parseIOS()`** - emit `Content-Range` after `content-length`, mirroring
`parseAndroid()`:

```dart
responseHeaders.add(
  'content-range: bytes $requestRangeStart-$requestRangeEnd/${requestRangeEnd + 1}',
);
```

**Both parsers** - clamp `endRange` at the top of the `while (downloading)`
loop before constructing each `DownloadTask`:

```dart
if (endRange > requestRangeEnd) endRange = requestRangeEnd;
```

---

## Tested with

- 2.4 MB MP4 (moov atom at tail) served from Aliyun OSS via the local proxy
- libmpv / media_kit on Windows
- Verified: tail frames no longer corrupt, seek no longer jumps to EOF