### PR TITLE
fix: write segments to .tmp and rename atomically; skip orphan .tmp files on startup

### DIFF
--- a/lib/cache/lru_cache_singleton.dart
+++ b/lib/cache/lru_cache_singleton.dart
@@ -153,12 +153,21 @@ class LruCacheSingleton {
       if (!(await cacheDir.exists())) return;
       for (FileSystemEntity file in cacheDir.listSync(recursive: true)) {
         FileStat stat = await file.stat();
-        if (stat.type == FileSystemEntityType.file) {
-          String key = basenameWithoutExtension(file.path);
-          // Restore through LruCacheStorage so size and per-key ledgers stay
-          // in sync. Writing map/size directly caused stale startup state.
-          await _storageCache.restore(key, file, stat.size);
+        if (stat.type != FileSystemEntityType.file) continue;
+        // In-flight downloads write to `.tmp` files. Any `.tmp` left on disk is an
+        // orphan from a previous crash/kill: delete it and never restore it into
+        // the index, otherwise an incomplete segment would be served as a
+        // complete one (decode artifacts / broken seek).
+        if (file.path.endsWith('.tmp')) {
+          try {
+            await file.delete();
+          } catch (_) {}
+          continue;
         }
+        String key = basenameWithoutExtension(file.path);
+        // Restore through LruCacheStorage so size and per-key ledgers stay
+        // in sync. Writing map/size directly caused stale startup state.
+        await _storageCache.restore(key, file, stat.size);
       }
     });
   }

--- a/lib/download/download_pool.dart
+++ b/lib/download/download_pool.dart
@@ -180,9 +180,14 @@ class DownloadPool {
     }
     bool append = task.cachedBytes > 0;
     Map<String, Object> headers = _downloadHeader(task);
+    // Write to a temp file and atomically rename it to the final name once the
+    // download completes. An interruption (or a killed process) leaves only a
+    // `.tmp` file, never a half-written segment under its final name (`.tmp` is
+    // skipped during startup restore — see LruCacheSingleton._storageInit).
+    final String tmpPath = '${task.savePath}.tmp';
     await _client.download(
       task.url,
-      task.savePath,
+      tmpPath,
       cancelToken: task.cancelToken,
       fileAccessMode: append ? FileAccessMode.append : FileAccessMode.write,
       deleteOnError: false,
@@ -247,7 +252,15 @@ class DownloadPool {
   }
 
   Future<void> _downloadResponse(DownloadTask task, DateTime startTime) async {
-    File saveFile = File(task.savePath);
+    final File tmpFile = File('${task.savePath}.tmp');
+    final File saveFile = File(task.savePath);
+    // Atomic publish: rename the completed `.tmp` to the final name. On Windows,
+    // renaming onto an existing path throws, so delete any stale file first. This
+    // guarantees the final name always points to a complete segment.
+    if (await saveFile.exists()) {
+      await saveFile.delete();
+    }
+    await tmpFile.rename(task.savePath);
     task.progress = 1;
     task.data = saveFile.readAsBytesSync();
     updateTaskById(task.id, DownloadStatus.COMPLETED);
@@ -268,14 +281,18 @@ class DownloadPool {
   }
 
   void _downloadError(DownloadTask task, dynamic error) {
-    File saveFile = File(task.savePath);
+    // Partial data lives in the `.tmp` file: keep it on cancel (= pause) so the
+    // download can resume, delete it on a real failure, and never let it reach
+    // the final name.
+    File tmpFile = File('${task.savePath}.tmp');
     // Check if the download was cancelled.
     if (error is DioException && CancelToken.isCancel(error)) {
-      logV('[DownloadPool] Download file size: ${saveFile.lengthSync()}');
+      logV('[DownloadPool] Download file size: '
+          '${tmpFile.existsSync() ? tmpFile.lengthSync() : 0}');
       logV('[DownloadPool] Download ${task.status.name}: ${task.url}');
     } else {
       // Handle HTTP errors and retry logic.
-      if (saveFile.existsSync()) saveFile.deleteSync();
+      if (tmpFile.existsSync()) tmpFile.deleteSync();
       updateTaskById(task.id, DownloadStatus.FAILED);
       logV('[DownloadPool] Download error: $error');
       if (error is DioException && error.response?.statusCode == 416) {


### PR DESCRIPTION
## Problem

If the app is killed or crashes while a segment is downloading, the partial
file is left on disk under its **final name**. On the next launch,
`LruCacheSingleton._storageInit` rescans the cache directory and restores
every file it finds into the LRU index - including these incomplete
segments. The parser then serves corrupt data from them instead of
re-downloading, causing decode artifacts and broken seek.

---

## Fix

### `DownloadPool` - write to `.tmp`, rename on completion

Instead of downloading directly to `task.savePath`, write to
`task.savePath + '.tmp'`:

```dart
final String tmpPath = '${task.savePath}.tmp';
await _client.download(task.url, tmpPath, ...);
```

On **successful completion** (`_downloadResponse`), atomically rename
`.tmp` ? final name. On Windows, renaming onto an existing path throws,
so any stale file is deleted first:

```dart
final File tmpFile = File('${task.savePath}.tmp');
final File saveFile = File(task.savePath);
if (await saveFile.exists()) await saveFile.delete();
await tmpFile.rename(task.savePath);
```

On **cancellation** (= pause), the `.tmp` is kept so in-session
pause/resume can continue appending to it.

On a **real download error**, the `.tmp` is deleted:

```dart
File tmpFile = File('${task.savePath}.tmp');
if (error is DioException && CancelToken.isCancel(error)) {
  // keep .tmp for resume
} else {
  if (tmpFile.existsSync()) tmpFile.deleteSync();
  ...
}
```

The final segment name is therefore **only ever created from a complete,
fully-written download**.

### `LruCacheSingleton._storageInit` - skip and delete orphan `.tmp` files

On startup, any `.tmp` file left on disk is an orphan from a previous
crash/kill. Delete it immediately and never restore it into the index:

```dart
if (file.path.endsWith('.tmp')) {
  try { await file.delete(); } catch (_) {}
  continue;
}
```

---

## Effect on the existing "resume interrupted download" feature

The plugin's resume feature works at the **segment level**: a completed
segment is reused from cache on the next launch; an incomplete segment
is simply re-downloaded fresh (? 1 MB with the default `segmentSize`).

Within a **single session**, pause/resume still works: cancellation keeps
the `.tmp` file and the `cachedBytes` counter, so the next download
appends from where it left off.

The only behaviour change is that a segment interrupted by a process kill
is re-downloaded on the next launch instead of being served corrupt.