### PR TITLE
Fix response status code 416

### DIFF
--- a/lib/download/download_pool.dart
+++ b/lib/download/download_pool.dart
@@ -254,7 +254,9 @@ class DownloadPool {
       if (range.isEmpty) range = 'bytes=0-';
       range += '${task.endRange}';
     }
-    headers.putIfAbsent('Range', () => range);
+    if (range.isNotEmpty) {
+      headers.putIfAbsent('Range', () => range);
+    }
     // Add custom headers except 'host' and 'range'.
     if (task.headers != null) {
       task.headers!.forEach((key, value) {


### PR DESCRIPTION
Fix this problem

flutter: \^[[38;5;244m [DownloadPool] Download error: DioException [bad response]: This exception was thrown because the response has a status code of 416 and RequestOptions.validateStatus was configured to throw for this status code.\^[[0m
flutter: \^[[38;5;244m The status code of 416 has the following meaning: "Client error - the request contains bad syntax or cannot be fulfilled"\^[[0m
flutter: \^[[38;5;244m Read more about status codes at https://developer.mozilla.org/en-US/docs/Web/HTTP/Status\^[[0m
flutter: \^[[38;5;244m In order to resolve this exception you typically have either to verify and fix your request code or you have to fix the server code.\^[[0m